### PR TITLE
Fixed time tolerance calculation in case API server time is behind the client server time

### DIFF
--- a/HMACAuthentication.WebApi/Filters/HMACAuthenticationAttribute.cs
+++ b/HMACAuthentication.WebApi/Filters/HMACAuthenticationAttribute.cs
@@ -151,8 +151,9 @@ namespace HMACAuthentication.WebApi.Filters
 
             var serverTotalSeconds = Convert.ToUInt64(currentTs.TotalSeconds);
             var requestTotalSeconds = Convert.ToUInt64(requestTimeStamp);
+            ulong difference = serverTotalSeconds > requestTotalSeconds ? serverTotalSeconds - requestTotalSeconds : requestTotalSeconds - serverTotalSeconds;
 
-            if ((serverTotalSeconds - requestTotalSeconds) > requestMaxAgeInSeconds)
+            if (difference > requestMaxAgeInSeconds)
             {
                 return true;
             }


### PR DESCRIPTION
Current time tolerance calculation is done on unsigned longs. This results in an excessively large value when the API server time is behind client server time. This fix handles the time difference in a manner similar to absolute value.